### PR TITLE
Add Stream.ExpectedStop() and export test utils

### DIFF
--- a/twitter/test_utils.go
+++ b/twitter/test_utils.go
@@ -1,0 +1,57 @@
+package twitter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+)
+
+// NewTestStream creates a Stream for testing with a provided input Messages channel.
+// It is safe to call Stop() once on the provided *Stream, as with a normal Stream.
+func NewTestStream(messages chan interface{}) *Stream {
+	return &Stream{
+		Messages: messages,
+		done:     make(chan struct{}),
+	}
+}
+
+// NewTestServer exposes testServer for test scaffolding in libraries that use go-twitter
+// it takes a map of path:functions to set the ServeMux.
+func NewTestServer(handlers map[string]func(w http.ResponseWriter, r *http.Request)) (*http.Client, *httptest.Server) {
+	client, mux, server := testServer()
+	for path, handler := range handlers {
+		mux.HandleFunc(path, handler)
+	}
+	return client, server
+}
+
+// testServer returns an http Client, ServeMux, and Server. The client proxies
+// requests to the server and handlers can be registered on the mux to handle
+// requests. The caller must close the test server.
+func testServer() (*http.Client, *http.ServeMux, *httptest.Server) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	transport := &RewriteTransport{&http.Transport{
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			return url.Parse(server.URL)
+		},
+	}}
+	client := &http.Client{Transport: transport}
+	return client, mux, server
+}
+
+// RewriteTransport rewrites https requests to http to avoid TLS cert issues
+// during testing.
+type RewriteTransport struct {
+	Transport http.RoundTripper
+}
+
+// RoundTrip rewrites the request scheme to http and calls through to the
+// composed RoundTripper or if it is nil, to the http.DefaultTransport.
+func (t *RewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "http"
+	if t.Transport == nil {
+		return http.DefaultTransport.RoundTrip(req)
+	}
+	return t.Transport.RoundTrip(req)
+}

--- a/twitter/twitter_test.go
+++ b/twitter/twitter_test.go
@@ -2,7 +2,6 @@ package twitter
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
@@ -11,37 +10,6 @@ import (
 )
 
 var defaultTestTimeout = time.Second * 1
-
-// testServer returns an http Client, ServeMux, and Server. The client proxies
-// requests to the server and handlers can be registered on the mux to handle
-// requests. The caller must close the test server.
-func testServer() (*http.Client, *http.ServeMux, *httptest.Server) {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	transport := &RewriteTransport{&http.Transport{
-		Proxy: func(req *http.Request) (*url.URL, error) {
-			return url.Parse(server.URL)
-		},
-	}}
-	client := &http.Client{Transport: transport}
-	return client, mux, server
-}
-
-// RewriteTransport rewrites https requests to http to avoid TLS cert issues
-// during testing.
-type RewriteTransport struct {
-	Transport http.RoundTripper
-}
-
-// RoundTrip rewrites the request scheme to http and calls through to the
-// composed RoundTripper or if it is nil, to the http.DefaultTransport.
-func (t *RewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.URL.Scheme = "http"
-	if t.Transport == nil {
-		return http.DefaultTransport.RoundTrip(req)
-	}
-	return t.Transport.RoundTrip(req)
-}
 
 func assertMethod(t *testing.T, expectedMethod string, req *http.Request) {
 	assert.Equal(t, expectedMethod, req.Method)


### PR DESCRIPTION
* Stream support `ExpectedStop()` function to determine whether Messages channel closed due to Stop() being called or some internal error
* expose `NewTestServer()` and `NewTestStream()` so that importing libraries can re-use internal test scaffolding for their own tests.